### PR TITLE
[wip] Adds git handler get master ref and apply production tag

### DIFF
--- a/lib/lita-zooniverse.rb
+++ b/lib/lita-zooniverse.rb
@@ -9,6 +9,7 @@ require "lita/handlers/deployment"
 require "lita/handlers/lintott"
 require "lita/handlers/aws_handler"
 require "lita/handlers/reload"
+require "lita/handlers/git"
 
 Lita::Handlers::Projects.template_root File.expand_path(
   File.join("..", "..", "templates"),

--- a/lib/lita/handlers/deployment.rb
+++ b/lib/lita/handlers/deployment.rb
@@ -47,7 +47,7 @@ module Lita
         comparison = Octokit.compare("zooniverse/panoptes", deployed_version, "production")
 
         if comparison.commits.empty?
-          response.reply("Production tag is the currently deployed version.")
+          response.reply("Production tag is currently deployed.")
         else
           word = comparison.commits.size > 1 ? "commits" : "commit"
           response.reply("#{comparison.commits.size} undeployed #{word}. #{comparison.permalink_url} :shipit:")

--- a/lib/lita/handlers/git.rb
+++ b/lib/lita/handlers/git.rb
@@ -9,14 +9,14 @@ module Lita
       route(/^panoptes tag production/, :tag_production, command: true, help: {"tag production" => "Applies the production tag to the current master commit"})
 
       def tag_production(response)
-        client.create_ref('zooniverse/panoptes', "tags/production", master.object.sha)
+        client.create_ref('zooniverse/panoptes', "tags/production", master_sha)
         response.reply("Production tag applied to current master commit.")
       rescue StandardError => e
         response.reply("Not sure. Try shouting really hard. (#{e.message})")
       end
 
       def master
-        @master ||= Octokit.ref('zooniverse/panoptes', 'heads/master').object.sha
+        @master ||= Octokit.ref('zooniverse/panoptes', 'heads/master')
       end
 
       def master_sha

--- a/lib/lita/handlers/git.rb
+++ b/lib/lita/handlers/git.rb
@@ -1,0 +1,33 @@
+require 'pry'
+
+module Lita
+  module Handlers
+    class Git < Handler
+      config :git_login, required: true
+      config :git_password, required: true
+
+      route(/^panoptes tag production/, :tag_production, command: true, help: {"tag production" => "Applies the production tag to the current master commit"})
+
+      def tag_production(response)
+        client.create_ref('zooniverse/panoptes', "tags/production", master.object.sha)
+        response.reply("Production tag applied to current master commit.")
+      rescue StandardError => e
+        response.reply("Not sure. Try shouting really hard. (#{e.message})")
+      end
+
+      def master
+        @master ||= Octokit.ref('zooniverse/panoptes', 'heads/master').object.sha
+      end
+
+      def master_sha
+        @master_sha ||= @master.object.sha
+      end
+
+      def client
+        @client = Octokit::Client.new(:login => config.git_login, :password => config.git_password)
+      end
+
+      Lita.register_handler(self)
+    end
+  end
+end

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -7,6 +7,8 @@ Lita.configure do |config|
   config.handlers.deployment.jenkins_username = ""
   config.handlers.deployment.jenkins_password = ""
   config.handlers.lintott.api_key = ""
+  config.handlers.git_login = ""
+  config.handlers.git_password = ""
 end
 
 require_relative 'lib/lita-zooniverse'


### PR DESCRIPTION
Just need a few questions answered to finish this off:

* Where are the ENV vars set? I don't see it in the infrastructure repo or in the production configs, and i can't tell if the `docker-lita` repo is actually used. We can set something up through the org for this but it'd be easier to just use a generated access token linked to my github account.

* How do I test this? I spent way longer trying to get specs together for this than the actual code, but they all ended up basically just stubbing and testing Octokit itself. I tried to get my own Lita running locally but didn't have any luck with either the `lita` or `docker-lita` repos. Since she basically lives in a box under your desk, I thought maybe you'd have a better idea how to test this.

what'd i miss?